### PR TITLE
fix: The use the CI tokens in docker image

### DIFF
--- a/predictible-tokens-for-ci/Dockerfile
+++ b/predictible-tokens-for-ci/Dockerfile
@@ -1,4 +1,4 @@
 FROM warp10io/warp10
 
 COPY ci.tokens ${WARP10_HOME}/etc/ci.tokens
-RUN sed s/"echo \"Launch Warp10\""/"echo\ \"warp\.token\.file\ \=\ \${WARP10_HOME}\/etc\/ci\.tokens\"\ \>\>\ \${WARP10_VOLUME}\/warp10\/etc\/conf\-standalone\.conf"/ /opt/warp10/bin/warp10.start.sh -i
+RUN sed '/echo "Launch Warp/a echo "warp.token.file=${WARP10_HOME}/etc/ci.tokens" > ${WARP10_HOME}/etc/conf.d/90-tokens-ci.conf' /opt/warp10/bin/warp10.start.sh -i


### PR DESCRIPTION
Add a new configuration file on start of Warp10 with CI tokens file variable.

Refs: #55